### PR TITLE
fix: handle branches without upstream during sync and push

### DIFF
--- a/git-ai.js
+++ b/git-ai.js
@@ -21,7 +21,26 @@ import { playFireworks } from './src/playFireworks.js';
 import { playStarWars } from './src/playStarWars.js';
 
 const pushChanges = (noVerify = false) => {
-  const pushCommand = noVerify ? "git push --no-verify" : "git push";
+  // Detect whether the current branch already has an upstream tracking branch.
+  // A brand new branch that has never been pushed has none, so a plain
+  // `git push` would fail with "no upstream branch". In that case, push with
+  // --set-upstream so the branch is created on the remote and tracked.
+  let hasUpstream = true
+  try {
+    execSync("git rev-parse --abbrev-ref --symbolic-full-name @{u}", { stdio: "ignore" })
+  } catch {
+    hasUpstream = false
+  }
+
+  const verifyFlag = noVerify ? " --no-verify" : ""
+  let pushCommand
+  if (hasUpstream) {
+    pushCommand = `git push${verifyFlag}`
+  } else {
+    const branch = execSync("git rev-parse --abbrev-ref HEAD").toString().trim()
+    pushCommand = `git push${verifyFlag} --set-upstream origin ${branch}`
+  }
+
   console.log(`\nRunning ${pushCommand}...\n`)
   execSync(pushCommand, {stdio: "inherit"})
 }

--- a/src/stageChanges.js
+++ b/src/stageChanges.js
@@ -61,7 +61,19 @@ export async function runPreCommitHooks(shouldPull = false, shouldSkipHooks = fa
     return true
   }
 
-  if (shouldPull) {
+  // A brand new branch that has never been pushed has no upstream tracking
+  // branch, so there is nothing to pull/rebase against. Skip the sync
+  // gracefully instead of failing with "no tracking information".
+  const syncStatus = shouldPull ? await git.status() : null
+  const hasUpstream = syncStatus ? Boolean(syncStatus.tracking) : false
+
+  if (shouldPull && !hasUpstream) {
+    ora().info(
+      `No upstream configured for branch "${syncStatus.current}". Skipping synchronization.`
+    )
+  }
+
+  if (shouldPull && hasUpstream) {
     const syncSpinner = ora("Synchronizing with remote repository...").start()
     try {
       // Use --autostash to automatically stash local changes (including staged) before pull and rebase


### PR DESCRIPTION
A brand new branch that has never been pushed has no upstream tracking branch, which caused 'git ai -p' to fail twice:

- 'git pull --rebase' failed with 'no tracking information for the current branch'. Now we check git status for an upstream first and skip synchronization gracefully when there is none, while still running the pre-commit hooks.
- 'git push' would then fail with 'no upstream branch'. pushChanges now detects the missing upstream and pushes with '--set-upstream origin <branch>' to create and track the branch.